### PR TITLE
La dp-kalkulator-api gå via dp-proxy i stedet for dp-reverse-proxy fo…

### DIFF
--- a/nais/dev/vars.yaml
+++ b/nais/dev/vars.yaml
@@ -9,6 +9,7 @@ accesspolicies: |
           - host: api-gw-q1.oera.no
           - host: login.microsoftonline.com
           - host: navtestb2c.b2clogin.com
+          - host: dp-proxy.dev-fss-pub.nais.io
 ingressess: |
   ingresses:
     - https://arbeid.dev.nav.no/arbeid/dagpenger/api/kalkulator

--- a/nais/prod/vars.yaml
+++ b/nais/prod/vars.yaml
@@ -8,6 +8,7 @@ accesspolicies: |
         external:
           - host: api-gw.oera.no
           - host: login.microsoftonline.com
+          - host: dp-proxy.prod-fss-pub.nais.io
 ingressess: |
   ingresses:
     - https://www.nav.no/arbeid/dagpenger/api/kalkulator

--- a/src/main/kotlin/no/nav/dagpenger/kalkulator/BehovStarter.kt
+++ b/src/main/kotlin/no/nav/dagpenger/kalkulator/BehovStarter.kt
@@ -2,7 +2,9 @@ package no.nav.dagpenger.kalkulator
 
 import com.github.kittinunf.fuel.httpPost
 import com.github.kittinunf.result.Result
+import io.ktor.http.HttpHeaders
 import io.prometheus.client.Counter
+import no.nav.dagpenger.aad.api.ClientCredentialsClient
 import java.time.LocalDate
 
 private val kontekstCounter = Counter
@@ -12,14 +14,13 @@ private val kontekstCounter = Counter
     .labelNames("kontekst")
     .register()
 
-class BehovStarter(
+internal class BehovStarter(
     private val regelApiUrl: String,
-    private val regelApiKey: String,
-    private val apiGatewayKey: String
+    private val tokenProvider: ClientCredentialsClient,
 ) {
     private val jsonAdapter = moshiInstance.adapter(BehovRequest::class.java)
 
-    fun startBehov(aktørId: String, regelkontekst: String): String {
+    suspend fun startBehov(aktørId: String, regelkontekst: String): String {
         kontekstCounter.labels(regelkontekst).inc()
 
         val behovUrl = "$regelApiUrl/behov"
@@ -27,8 +28,7 @@ class BehovStarter(
 
         val (_, response, result) =
             behovUrl.httpPost()
-                .apiKey(regelApiKey)
-                .header("x-nav-apiKey" to apiGatewayKey)
+                .header(HttpHeaders.Authorization, "Bearer ${tokenProvider.getAccessToken()}")
                 .header(mapOf("Content-Type" to "application/json"))
                 .body(json)
                 .response()
@@ -38,7 +38,7 @@ class BehovStarter(
                 "Failed to run behov. Response message ${response.responseMessage}. Error message: ${result.error.message}"
             )
             is Result.Success ->
-                response.headers["Location"].first()
+                response.headers["Location"].first().replaceFirst("/v1/", "/")
         }
     }
 }

--- a/src/main/kotlin/no/nav/dagpenger/kalkulator/BehovStatusPoller.kt
+++ b/src/main/kotlin/no/nav/dagpenger/kalkulator/BehovStatusPoller.kt
@@ -27,8 +27,6 @@ class BehovStatusPoller(
             .allowRedirects(false)
             .responseString()
 
-        LOGGER.info { "Got ${response.statusCode} from $statusUrl" }
-
         return result.fold(
             success = {
                 when (response.statusCode) {

--- a/src/main/kotlin/no/nav/dagpenger/kalkulator/Configuration.kt
+++ b/src/main/kotlin/no/nav/dagpenger/kalkulator/Configuration.kt
@@ -14,9 +14,10 @@ private val localProperties = ConfigurationMap(
     mapOf(
         "API_GATEWAY_API_KEY" to "hunter2",
         "API_GATEWAY_URL" to "http://localhost/",
-        "GRAPH_QL_KEY" to "hunter2",
         "PDL_API_SCOPE" to "api://dev-fss.pdl.pdl-api/.default",
         "PDL_API_URL" to "https://pdl-api.dev-fss-pub.nais.io/graphql",
+        "DP_PROXY_SCOPE" to "api://dev-fss.teamdagpenger.dp-proxy/.default",
+        "DP_PROXY_URL" to "https://dp-proxy.dev-fss-pub.nais.io",
         "application.httpPort" to "8099",
         "application.profile" to "LOCAL",
         "forskudd.api.key" to "hunter2",
@@ -33,6 +34,8 @@ private val devProperties = ConfigurationMap(
     mapOf(
         "PDL_API_SCOPE" to "api://dev-fss.pdl.pdl-api/.default",
         "PDL_API_URL" to "https://pdl-api.dev-fss-pub.nais.io/graphql",
+        "DP_PROXY_SCOPE" to "api://dev-fss.teamdagpenger.dp-proxy/.default",
+        "DP_PROXY_URL" to "https://dp-proxy.dev-fss-pub.nais.io",
         "application.httpPort" to "8099",
         "application.profile" to "DEV",
         "jwks.issuer" to "https://login.microsoftonline.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/",
@@ -45,6 +48,8 @@ private val prodProperties = ConfigurationMap(
     mapOf(
         "PDL_API_SCOPE" to "api://prod-fss.pdl.pdl-api/.default",
         "PDL_API_URL" to "https://pdl-api.prod-fss-pub.nais.io/graphql",
+        "DP_PROXY_SCOPE" to "api://prod-fss.teamdagpenger.dp-proxy/.default",
+        "DP_PROXY_URL" to "https://dp-proxy.prod-fss-pub.nais.io",
         "application.httpPort" to "8099",
         "application.profile" to "PROD",
         "jwks.issuer" to "https://login.microsoftonline.com/8b7dfc8b-b52e-4741-bde4-d83ea366f94f/v2.0/",
@@ -74,16 +79,21 @@ data class Configuration(
         val jwksUrlNy: String = config()[Key("jwks.url.ny", stringType)],
         val jwksIssuerNy: String = config()[Key("jwks.issuer.ny", stringType)],
         val name: String = "dp-kalkulator-api",
-        val apiGatewayBaseUrl: String = config()[Key("API_GATEWAY_URL", stringType)],
-        val apiGatewayKey: String = config()[Key("API_GATEWAY_API_KEY", stringType)],
-        val regelApiBaseUrl: String = config()[Key("API_GATEWAY_URL", stringType)] + "dp-regel-api",
+
         val pdlApiBaseUrl: String = config()[Key("PDL_API_URL", stringType)],
         val forskuddApiKey: String = config()[Key("forskudd.api.key", stringType)],
-        val basePath: String = config().getOrElse(Key("app.basepath", stringType), "/arbeid/dagpenger/kalkulator-api")
+        val basePath: String = config().getOrElse(Key("app.basepath", stringType), "/arbeid/dagpenger/kalkulator-api"),
+        val dpProxyUrl: String = config()[Key("DP_PROXY_URL", stringType)] + "/proxy/v1/regelapi",
     ) {
         fun tokenProvider() = ClientCredentialsClient(config()) {
             scope {
                 add(config()[Key("PDL_API_SCOPE", stringType)])
+            }
+        }
+
+        fun dpProxyTokenProvider() = ClientCredentialsClient(config()) {
+            scope {
+                add(config()[Key("DP_PROXY_SCOPE", stringType)])
             }
         }
     }

--- a/src/main/kotlin/no/nav/dagpenger/kalkulator/DagpengeKalkulator.kt
+++ b/src/main/kotlin/no/nav/dagpenger/kalkulator/DagpengeKalkulator.kt
@@ -13,13 +13,13 @@ private val resultatCounter = Counter
     .labelNames("resultat")
     .register()
 
-class DagpengeKalkulator(
+internal class DagpengeKalkulator(
     private val behovStarter: BehovStarter,
     private val behovStatusPoller: BehovStatusPoller,
     private val subsumsjonFetcher: SubsumsjonFetcher
 ) {
     suspend fun kalkuler(aktørId: String, regelkontekst: String): KalkulasjonsResult {
-        LOGGER.info { "starting behov, trying " + config.application.regelApiBaseUrl + "/behov" }
+        LOGGER.info { "starting behov, trying " + config.application.dpProxyUrl + "/behov" }
         val pollLocation = behovStarter.startBehov(aktørId, regelkontekst)
         LOGGER.info("Location: $pollLocation")
 

--- a/src/main/kotlin/no/nav/dagpenger/kalkulator/KalkulatorApp.kt
+++ b/src/main/kotlin/no/nav/dagpenger/kalkulator/KalkulatorApp.kt
@@ -59,11 +59,11 @@ fun main() {
         config.application.tokenProvider()
     )
     val behovStarter =
-        BehovStarter(config.application.regelApiBaseUrl, config.auth.regelApiKey, config.application.apiGatewayKey)
+        BehovStarter(config.application.dpProxyUrl, config.application.dpProxyTokenProvider())
     val behovStatusPoller =
-        BehovStatusPoller(config.application.regelApiBaseUrl, config.auth.regelApiKey, config.application.apiGatewayKey)
+        BehovStatusPoller(config.application.dpProxyUrl, config.application.dpProxyTokenProvider())
     val subsumsjonFetcher =
-        SubsumsjonFetcher(config.application.regelApiBaseUrl, config.auth.regelApiKey, config.application.apiGatewayKey)
+        SubsumsjonFetcher(config.application.dpProxyUrl, config.application.dpProxyTokenProvider())
     val dagpengeKalkulator = DagpengeKalkulator(behovStarter, behovStatusPoller, subsumsjonFetcher)
 
     val application = embeddedServer(Netty, port = config.application.httpPort) {

--- a/src/main/kotlin/no/nav/dagpenger/kalkulator/RequestExtensionApiKey.kt
+++ b/src/main/kotlin/no/nav/dagpenger/kalkulator/RequestExtensionApiKey.kt
@@ -1,5 +1,0 @@
-package no.nav.dagpenger.kalkulator
-
-import com.github.kittinunf.fuel.core.Request
-
-internal fun Request.apiKey(apiKey: String) = this.header("X-API-KEY", apiKey)

--- a/src/main/kotlin/no/nav/dagpenger/kalkulator/SubsumsjonFetcher.kt
+++ b/src/main/kotlin/no/nav/dagpenger/kalkulator/SubsumsjonFetcher.kt
@@ -3,14 +3,15 @@ package no.nav.dagpenger.kalkulator
 import com.github.kittinunf.fuel.httpGet
 import com.github.kittinunf.fuel.moshi.moshiDeserializerOf
 import com.github.kittinunf.result.Result
+import io.ktor.http.HttpHeaders
+import no.nav.dagpenger.aad.api.ClientCredentialsClient
 
 class SubsumsjonFetcher(
     private val regelApiUrl: String,
-    private val regelApiKey: String,
-    private val apiGatewayKey: String
+    private val tokenProvider: ClientCredentialsClient,
 ) {
 
-    fun getSubsumsjon(subsumsjonLocation: String): Subsumsjon {
+    suspend fun getSubsumsjon(subsumsjonLocation: String): Subsumsjon {
         val url = "$regelApiUrl$subsumsjonLocation"
 
         val jsonAdapter = moshiInstance.adapter(Subsumsjon::class.java)
@@ -19,8 +20,7 @@ class SubsumsjonFetcher(
             with(
                 url
                     .httpGet()
-                    .header("x-nav-apiKey" to apiGatewayKey)
-                    .apiKey(regelApiKey)
+                    .header(HttpHeaders.Authorization, "Bearer ${tokenProvider.getAccessToken()}")
             ) { responseObject(moshiDeserializerOf(jsonAdapter)) }
 
         return when (result) {

--- a/src/test/kotlin/no/nav/dagpenger/kalkulator/KalkulatorApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/kalkulator/KalkulatorApiTest.kt
@@ -9,9 +9,8 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
 import io.mockk.coEvery
-import io.mockk.every
+import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.verify
 import io.prometheus.client.CollectorRegistry
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
@@ -67,15 +66,15 @@ internal class KalkulatorApiTest {
             aktørIdOppslagKlient.fetchAktørIdGraphql(any())
         } returns "1234"
 
-        every {
+        coEvery {
             behovStarter.startBehov("1234", regelkontekst)
         } returns "htto://localhost/1234"
 
-        every {
-            runBlocking { behovStatusPoller.pollStatus("htto://localhost/1234") }
+        coEvery {
+            behovStatusPoller.pollStatus("htto://localhost/1234")
         } returns "htto://localhost/1234"
 
-        every {
+        coEvery {
             subsumsjonFetcher.getSubsumsjon("htto://localhost/1234")
         } returns Subsumsjon(
             behovId = "1234",
@@ -151,11 +150,11 @@ internal class KalkulatorApiTest {
             aktørIdOppslagKlient.fetchAktørIdGraphql(any())
         } returns "1234"
 
-        every {
+        coEvery {
             behovStarter.startBehov("1234", regelkontekst)
         } returns "htto://localhost/1234"
 
-        every {
+        coEvery {
             behovStarter.startBehov("", "corona")
         } returns "htto://localhost/1234"
 
@@ -174,7 +173,7 @@ internal class KalkulatorApiTest {
                 )
             }
         }
-        verify { behovStarter.startBehov("1234", regelkontekst) }
+        coVerify { behovStarter.startBehov("1234", regelkontekst) }
     }
 
     @Test
@@ -196,15 +195,15 @@ internal class KalkulatorApiTest {
             aktørIdOppslagKlient.fetchAktørIdGraphql(any())
         } returns "1234"
 
-        every {
+        coEvery {
             behovStarter.startBehov("1234", any())
         } returns "htto://localhost/1234"
 
-        every {
-            runBlocking { behovStatusPoller.pollStatus("htto://localhost/1234") }
+        coEvery {
+            behovStatusPoller.pollStatus("htto://localhost/1234")
         } returns "htto://localhost/1234"
 
-        every {
+        coEvery {
             subsumsjonFetcher.getSubsumsjon("htto://localhost/1234")
         } returns Subsumsjon(
             behovId = "1234",
@@ -293,15 +292,15 @@ internal class KalkulatorApiTest {
             aktørIdOppslagKlient.fetchAktørIdGraphql(any())
         } returns "1234"
 
-        every {
+        coEvery {
             behovStarter.startBehov("1234", any())
         } returns "htto://localhost/1234"
 
-        every {
+        coEvery {
             runBlocking { behovStatusPoller.pollStatus("htto://localhost/1234") }
         } returns "htto://localhost/1234"
 
-        every {
+        coEvery {
             subsumsjonFetcher.getSubsumsjon("htto://localhost/1234")
         } returns Subsumsjon(
             behovId = "1234",


### PR DESCRIPTION
…r å nå dp-regel-api

navikt/dagpenger#939


La kalkulator APIet gå via [dp-proxy](https://github.com/navikt/dp-proxy) istedet for [dp-reverse-proxy](https://github.com/navikt/dp-reverse-proxy) 

[dp-reverse-proxy](https://github.com/navikt/dp-reverse-proxy)  er en fork av [helse-proxy](https://github.com/navikt/helse-reverse-proxy) og hjemmemekka ktor clienter fra [dusseldorf-ktor](https://github.com/navikt/dusseldorf-ktor). Vi ligger laangt etter ktor oppgradering, og trenger ikke alt som ligger i dusseldorf-ktor


[dp-proxy](https://github.com/navikt/dp-proxy) ble laget i forbindelse med dp-mottak og har clienter mot regel-apiet.
Den bruker ikke api gateway og den slags.
Den bruker ikke hjemmesnekra API key mot regel-api

Vi kan fjerne og arkivere [dp-reverse-proxy](https://github.com/navikt/dp-reverse-proxy) når denne er ute. 



Branchen testet ok  i dev via https://arbeid.dev.nav.no/arbeid/dagpenger/kalkulator/


Commits i dp-proxy for tilpasninger:
- https://github.com/navikt/dp-proxy/commit/a29e0418ec8a8b31da13ee386f3fc140ab4592e5
- https://github.com/navikt/dp-proxy/commit/0066583e68fabfb8cf995dcf28dc7488b2b77eb8
 





